### PR TITLE
fix: disable cache in deserializer

### DIFF
--- a/src/expose.ts
+++ b/src/expose.ts
@@ -63,7 +63,7 @@ export const expose = <Props>(Component: React.FC<Props>, key?: string) => {
     if (!id || !props) {
       throw new Error('no id or props found');
     }
-    const deserialized = deserialize(props) as PropsWithChildren<Props>; // unsafe type assertion
+    const deserialized = deserialize(props, key) as PropsWithChildren<Props>; // unsafe type assertion
     const thunk = () => {
       try {
         const ele = render(Component, deserialized);

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -11,7 +11,7 @@ const createElement = (
   { children, ...props }: Record<string, unknown>,
 ) => {
   if (Array.isArray(children)) {
-    return createElementOrig(type, props, ...children as ReactNode[]);
+    return createElementOrig(type, props, ...(children as ReactNode[]));
   }
   if (children) {
     return createElementOrig(type, props, children as ReactNode);
@@ -24,12 +24,12 @@ const eleSymbol = Symbol.for('react.element');
 
 type Serialized =
   | { v: unknown }
-  | { i: number } & (
-    | { e: { props: Serialized; type: string | { c: string } } }
-    | { a: Serialized[] }
-    | { o: Record<string, Serialized> }
-    | { u: object }
-  );
+  | ({ i: number } & (
+      | { e: { props: Serialized; type: string | { c: string } } }
+      | { a: Serialized[] }
+      | { o: Record<string, Serialized> }
+      | { u: object }
+    ));
 
 const isSerialized = (x: unknown): x is Serialized => {
   if (typeof process === 'object' && process.env.NODE_ENV !== 'production') {
@@ -67,7 +67,7 @@ const obj2idx = new WeakMap<object, number>();
 
 const isWorker = typeof self !== 'undefined' && !self.document;
 let index = 0;
-const nextIndex = isWorker ? (() => ++index) : (() => --index);
+const nextIndex = isWorker ? () => ++index : () => --index;
 
 let lastGcSize = 0;
 const gc = () => {
@@ -96,9 +96,10 @@ export const serialize = (x: unknown): Serialized => {
   if ((x as { [eleTypeof]: unknown })[eleTypeof] === eleSymbol) {
     const e = {
       props: serialize((x as { props: unknown }).props),
-      type: typeof (x as { type: unknown }).type === 'string'
-        ? (x as { type: string }).type
-        : { c: getName((x as { type: ComponentType }).type) },
+      type:
+        typeof (x as { type: unknown }).type === 'string'
+          ? (x as { type: string }).type
+          : { c: getName((x as { type: ComponentType }).type) },
     };
     return { i, e };
   }
@@ -117,7 +118,12 @@ export const serialize = (x: unknown): Serialized => {
   return { i, u: x };
 };
 
-export const deserialize = (x: unknown): unknown => {
+let currentComp: string | undefined;
+
+export const deserialize = (x: unknown, key?: string): unknown => {
+  if (currentComp !== key) idx2obj.clear();
+  currentComp = key;
+
   if (!isSerialized(x)) throw new Error('not serialized type');
   if ('v' in x) return x.v;
   if (idx2obj.has(x.i)) {
@@ -127,22 +133,23 @@ export const deserialize = (x: unknown): unknown => {
     }
   }
   if ('e' in x) {
-    const type = typeof x.e.type === 'string'
-      ? x.e.type
-      : getComponent(x.e.type.c);
-    const ele: object = createElement(type, deserialize(x.e.props) as Record<string, unknown>);
+    const type = typeof x.e.type === 'string' ? x.e.type : getComponent(x.e.type.c);
+    const ele: object = createElement(
+      type,
+      deserialize(x.e.props, key) as Record<string, unknown>,
+    );
     idx2obj.set(x.i, new WeakRef(ele));
     return ele;
   }
   if ('a' in x) {
-    const arr = x.a.map(deserialize);
+    const arr = x.a.map((v) => deserialize(v, key));
     idx2obj.set(x.i, new WeakRef(arr));
     return arr;
   }
   if ('o' in x) {
     const obj: Record<string, unknown> = {};
     Object.entries(x.o).forEach(([key, val]) => {
-      obj[key] = deserialize(val);
+      obj[key] = deserialize(val, key);
     });
     idx2obj.set(x.i, new WeakRef(obj));
     return obj;

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -52,7 +52,7 @@ export const wrap = <Props = EmptyObject>(
           if (err) {
             entry.err = err;
           } else {
-            entry.result = deserialize(ele);
+            entry.result = deserialize(ele, key);
           }
           entry.resolve?.();
         }


### PR DESCRIPTION
We sometimes return the first component when rendering the second one because of cache and `idx2obj`, so here, in every element, we clear the cache first!
With this, https://github.com/Aslemammad/react-worker-components-plugin/runs/5167585837?check_suite_focus=true is going to be fixed.